### PR TITLE
Autoload and custom group for settings

### DIFF
--- a/logstash-conf.el
+++ b/logstash-conf.el
@@ -34,7 +34,14 @@
 ;;; Code:
 (require 'conf-mode)
 
-(defvar logstash-indent 8)
+(defgroup logstash nil
+  "Major mode for editing Logstash configuration files."
+  :group 'languages)
+
+(defcustom logstash-indent 8
+  "Indentation offset for `logstash-conf-mode'"
+  :group 'logstash
+  :type 'integer)
 
 (defun logstash--get-faces (pos)
   "Get all the font faces at POS."


### PR DESCRIPTION
These are two minor commits that:
- Make `logstash-conf-mode` autoloaded so a user can do `M-x logstash-conf-mode` without requiring the package first
- Create a `logstash` group and add the `logstash-indent` setting to it so it can be customized. Any future settings can be added to this group so someone can do `M-x customize-group logstash` and see all the settings.
