### PR TITLE
Manually require 'cl-lib, use `cl-incf` and `cl-decf`

### DIFF
--- a/logstash-conf.el
+++ b/logstash-conf.el
@@ -33,7 +33,7 @@
 
 ;;; Code:
 (require 'conf-mode)
-(require 'cl)
+(require 'cl-lib)
 
 (defgroup logstash nil
   "Major mode for editing Logstash configuration files."


### PR DESCRIPTION
Previously it was possible to get:

```
logstash--open-paren-count: Invalid function: incf
```

The `cl-` prefix versions are more recommended I believe.
